### PR TITLE
feat: enforce canonical lifecycle status in conformance

### DIFF
--- a/conformance/suite.py
+++ b/conformance/suite.py
@@ -15,6 +15,19 @@ class ContractResult:
     details: str
 
 
+CANONICAL_INTENT_STATUSES = {
+    "CREATED",
+    "SUBMITTED",
+    "DELIVERED",
+    "ACKNOWLEDGED",
+    "IN_PROGRESS",
+    "WAITING",
+    "COMPLETED",
+    "FAILED",
+    "CANCELED",
+}
+
+
 def run_contract_suite(
     *,
     base_url: str,
@@ -188,6 +201,8 @@ def _check_intent_create_contract(client: httpx.Client) -> ContractResult:
         return ContractResult("intent_create", False, "missing field: intent_id")
     if not _is_uuid(data["intent_id"]):
         return ContractResult("intent_create", False, "intent_id is not UUID")
+    if data.get("status") not in CANONICAL_INTENT_STATUSES:
+        return ContractResult("intent_create", False, "create status is not canonical lifecycle status")
     return ContractResult("intent_create", True, "ok")
 
 
@@ -252,6 +267,8 @@ def _check_intents_get_contract(client: httpx.Client) -> ContractResult:
         return ContractResult("intents_get", False, "missing or invalid field: intent_type")
     if not isinstance(intent.get("payload"), dict):
         return ContractResult("intents_get", False, "missing or invalid field: payload")
+    if intent.get("status") not in CANONICAL_INTENT_STATUSES:
+        return ContractResult("intents_get", False, "intent.status is not canonical lifecycle status")
 
     return ContractResult("intents_get", True, "ok")
 
@@ -283,9 +300,19 @@ def _check_intents_events_contract(client: httpx.Client) -> ContractResult:
             return ContractResult("intents_events", False, "invalid event seq")
         if not isinstance(event_type, str) or not event_type.startswith("intent."):
             return ContractResult("intents_events", False, "invalid event_type")
+        if item.get("status") not in CANONICAL_INTENT_STATUSES:
+            return ContractResult("intents_events", False, "event status is not canonical lifecycle status")
         seqs.append(seq)
     if seqs != sorted(seqs):
         return ContractResult("intents_events", False, "events are not ordered by seq")
+    expected_prefix = ["intent.created", "intent.submitted", "intent.delivered"]
+    observed_prefix = [item.get("event_type") for item in events[:3]]
+    if observed_prefix != expected_prefix:
+        return ContractResult(
+            "intents_events",
+            False,
+            f"unexpected lifecycle prefix: {observed_prefix}",
+        )
 
     first_seq = seqs[0]
     since_response = client.get(f"/v1/intents/{intent_id}/events", params={"since": first_seq})
@@ -370,6 +397,9 @@ def _check_intents_resolve_contract(client: httpx.Client) -> ContractResult:
         return ContractResult("intents_resolve", False, "resolve did not emit terminal completed event")
     if event.get("status") != "COMPLETED":
         return ContractResult("intents_resolve", False, "resolve status mismatch")
+    resolved_intent = resolve_data.get("intent")
+    if not isinstance(resolved_intent, dict) or resolved_intent.get("status") != "COMPLETED":
+        return ContractResult("intents_resolve", False, "resolved intent projection is not terminal canonical status")
 
     second_terminal = client.post(
         f"/v1/intents/{intent_id}/resolve",

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -200,7 +200,7 @@ def test_run_contract_suite_happy_path() -> None:
                 "details": details,
             }
             events.append(terminal_event)
-            intents[intent_id_from_path]["status"] = "failed" if status == "FAILED" else "done"
+            intents[intent_id_from_path]["status"] = status
             intents[intent_id_from_path]["updated_at"] = "2026-02-28T00:00:10Z"
             completion_delivery: dict[str, object] = {"delivered": False, "reason": "reply_to_not_set"}
             reply_to = intents[intent_id_from_path].get("reply_to")
@@ -259,7 +259,7 @@ def test_run_contract_suite_happy_path() -> None:
             def _store_intent(intent_id_value: str) -> None:
                 intents[intent_id_value] = {
                     "intent_id": intent_id_value,
-                    "status": "accepted",
+                    "status": "DELIVERED",
                     "created_at": "2026-02-28T00:00:00Z",
                     "updated_at": "2026-02-28T00:00:01Z",
                     "intent_type": body.get("intent_type", "notify.message.v1"),
@@ -292,6 +292,17 @@ def test_run_contract_suite_happy_path() -> None:
                         "at": "2026-02-28T00:00:01Z",
                         "details": {"source": "conformance"},
                     },
+                    {
+                        "intent_id": intent_id_value,
+                        "seq": 3,
+                        "event_type": "intent.delivered",
+                        "status": "DELIVERED",
+                        "waiting_reason": None,
+                        "handler": intents[intent_id_value]["to_agent"],
+                        "actor": "gateway",
+                        "at": "2026-02-28T00:00:01Z",
+                        "details": {"source": "conformance"},
+                    },
                 ]
 
             idempotency_key = request.headers.get("idempotency-key")
@@ -303,14 +314,14 @@ def test_run_contract_suite_happy_path() -> None:
                         return httpx.Response(409, json={"error": "idempotency_conflict"})
                     if previous_intent_id not in intents:
                         _store_intent(previous_intent_id)
-                    return httpx.Response(200, json={"intent_id": previous_intent_id})
+                    return httpx.Response(200, json={"intent_id": previous_intent_id, "status": intents[previous_intent_id]["status"]})
                 new_intent_id = str(uuid4())
                 idempotency_cache[idempotency_key] = (payload_signature, new_intent_id)
                 _store_intent(new_intent_id)
-                return httpx.Response(200, json={"intent_id": new_intent_id})
+                return httpx.Response(200, json={"intent_id": new_intent_id, "status": intents[new_intent_id]["status"]})
             generated_intent_id = str(uuid4())
             _store_intent(generated_intent_id)
-            return httpx.Response(200, json={"intent_id": generated_intent_id})
+            return httpx.Response(200, json={"intent_id": generated_intent_id, "status": intents[generated_intent_id]["status"]})
         if request.url.path == "/v1/inbox":
             owner_agent = request.url.params.get("owner_agent")
             if owner_agent == "agent://conformance/owner":


### PR DESCRIPTION
## Summary
- require canonical lifecycle status projection for intent create/get checks
- require canonical lifecycle status values on intent events and delivered-prefix lifecycle ordering
- update mock suite transport responses to emit canonical status values consistently

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest`

Made with [Cursor](https://cursor.com)