### PR TITLE
test: add expired access-request transition conformance checks

### DIFF
--- a/conformance/suite.py
+++ b/conformance/suite.py
@@ -1398,6 +1398,61 @@ def _check_enterprise_access_requests_contract(client: httpx.Client) -> Contract
             )
         if reviewed_request.get("reviewer_actor_id") != "actor://conformance/reviewer":
             return ContractResult("enterprise_access_requests", False, "reviewer_actor_id was not persisted")
+
+    expired_create_response = client.post(
+        "/v1/access-requests",
+        json={
+            "request_type": "join_organization",
+            "requester_actor_id": "actor://conformance/requester",
+            "org_id": org_id,
+            "requested_role": "member",
+            "justification": "expired transition contract check",
+            "expires_at": "2000-01-01T00:00:00Z",
+        },
+    )
+    if expired_create_response.status_code != 200:
+        return ContractResult(
+            "enterprise_access_requests",
+            False,
+            f"expired access request create status={expired_create_response.status_code}",
+        )
+    expired_create_data = expired_create_response.json()
+    expired_access_request = expired_create_data.get("access_request")
+    if expired_create_data.get("ok") is not True or not isinstance(expired_access_request, dict):
+        return ContractResult("enterprise_access_requests", False, "invalid expired access request create response shape")
+    expired_access_request_id = expired_access_request.get("access_request_id")
+    if not _is_uuid(expired_access_request_id):
+        return ContractResult("enterprise_access_requests", False, "invalid expired access_request_id")
+    if expired_access_request.get("state") != "expired":
+        return ContractResult("enterprise_access_requests", False, "stale access request did not transition to expired")
+
+    expired_list_response = client.get(
+        "/v1/access-requests",
+        params={"org_id": org_id, "state": "expired"},
+    )
+    if expired_list_response.status_code != 200:
+        return ContractResult("enterprise_access_requests", False, f"expired list status={expired_list_response.status_code}")
+    expired_list_data = expired_list_response.json()
+    expired_rows = expired_list_data.get("access_requests")
+    if expired_list_data.get("ok") is not True or not isinstance(expired_rows, list):
+        return ContractResult("enterprise_access_requests", False, "invalid expired access request list response shape")
+    if not any(isinstance(item, dict) and item.get("access_request_id") == expired_access_request_id for item in expired_rows):
+        return ContractResult("enterprise_access_requests", False, "expired access request not present in expired-state listing")
+
+    expired_review_response = client.post(
+        f"/v1/access-requests/{expired_access_request_id}/review",
+        json={
+            "decision": "approve",
+            "reviewer_actor_id": "actor://conformance/reviewer",
+            "review_comment": "expired review should fail",
+        },
+    )
+    if expired_review_response.status_code != 409:
+        return ContractResult(
+            "enterprise_access_requests",
+            False,
+            f"expected expired review status=409 got={expired_review_response.status_code}",
+        )
     return ContractResult("enterprise_access_requests", True, "ok")
 
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -233,10 +233,12 @@ def test_run_contract_suite_happy_path() -> None:
                 return httpx.Response(401, json={"error": "unauthorized"})
             body = json.loads(request.content.decode("utf-8"))
             access_request_id = str(uuid4())
+            expires_at = body.get("expires_at") if isinstance(body.get("expires_at"), str) else None
+            is_expired = isinstance(expires_at, str) and expires_at <= "2026-02-28T00:00:00Z"
             access_request = {
                 "access_request_id": access_request_id,
                 "request_type": body["request_type"],
-                "state": "pending",
+                "state": "expired" if is_expired else "pending",
                 "requester_actor_id": body["requester_actor_id"],
                 "org_id": body.get("org_id"),
                 "workspace_id": body.get("workspace_id"),
@@ -246,17 +248,40 @@ def test_run_contract_suite_happy_path() -> None:
                 "reviewer_actor_id": None,
                 "review_comment": None,
                 "reviewed_at": None,
+                "expires_at": expires_at,
                 "created_at": "2026-02-28T00:00:00Z",
                 "updated_at": "2026-02-28T00:00:00Z",
             }
             access_requests[access_request_id] = access_request
             return httpx.Response(200, json={"ok": True, "access_request": access_request})
+        if request.url.path == "/v1/access-requests" and request.method == "GET":
+            if not has_authorization(request):
+                return httpx.Response(401, json={"error": "unauthorized"})
+            org_id = request.url.params.get("org_id")
+            workspace_id = request.url.params.get("workspace_id")
+            state_filter = request.url.params.get("state")
+            rows: list[dict[str, object]] = []
+            for item in access_requests.values():
+                item_org = item.get("org_id")
+                item_workspace = item.get("workspace_id")
+                item_state = item.get("state")
+                if isinstance(org_id, str) and item_org != org_id:
+                    continue
+                if isinstance(workspace_id, str) and item_workspace != workspace_id:
+                    continue
+                if isinstance(state_filter, str) and item_state != state_filter:
+                    continue
+                rows.append(item)
+            return httpx.Response(200, json={"ok": True, "access_requests": rows})
         if request.url.path.startswith("/v1/access-requests/") and request.url.path.endswith("/review") and request.method == "POST":
             if not has_authorization(request):
                 return httpx.Response(401, json={"error": "unauthorized"})
             access_request_id = request.url.path.split("/v1/access-requests/")[1].split("/review")[0]
             if access_request_id not in access_requests:
                 return httpx.Response(404, json={"error": "not_found"})
+            current_state = access_requests[access_request_id].get("state")
+            if current_state not in {"pending", "under_review"}:
+                return httpx.Response(409, json={"error": "not_reviewable"})
             body = json.loads(request.content.decode("utf-8"))
             review_state_by_decision = {
                 "approve": "approved",


### PR DESCRIPTION
## Summary
- extend enterprise access-request contract with explicit stale->expired transition checks
- validate expired-state listing and expired review conflict (`409`) semantics
- update conformance mock handler to support access-request listing and expired review behavior

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q tests/test_suite.py -k "run_contract_suite_happy_path or run_contract_suite_reports_failures"`

Made with [Cursor](https://cursor.com)