### PR TITLE
test: extend routing delivery conformance for fallback and reconcile

### DIFF
--- a/conformance/suite.py
+++ b/conformance/suite.py
@@ -1937,9 +1937,11 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
         json={
             "principal_id": principal_id,
             "transport_type": "http",
-            "endpoint_url": "https://conformance-router.example/intents",
+            "endpoint_url": "https://conformance-router-primary.example/intents",
             "auth_mode": "jwt",
-            "priority": 10,
+            "region": "us-central1",
+            "failover_policy": "same_region",
+            "priority": 5,
         },
     )
     if route_response.status_code != 200:
@@ -1954,6 +1956,44 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     route_id = route_payload.get("route_id")
     if not isinstance(route_id, str) or len(route_id) < 8:
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid route_id")
+
+    primary_mark_unhealthy = client.patch(
+        f"/v1/routing/endpoints/{route_id}",
+        json={"health_status": "unhealthy"},
+    )
+    if primary_mark_unhealthy.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"primary route health update status={primary_mark_unhealthy.status_code}")
+
+    fallback_route_response = client.post(
+        "/v1/routing/endpoints",
+        json={
+            "principal_id": principal_id,
+            "transport_type": "http",
+            "endpoint_url": "https://conformance-router-fallback.example/intents",
+            "auth_mode": "jwt",
+            "region": "us-central1",
+            "priority": 10,
+        },
+    )
+    if fallback_route_response.status_code != 200:
+        return ContractResult(
+            "enterprise_naming_routing_delivery",
+            False,
+            f"routing fallback endpoint register status={fallback_route_response.status_code}",
+        )
+    fallback_route_payload = fallback_route_response.json().get("route")
+    if not isinstance(fallback_route_payload, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid fallback route response shape")
+    fallback_route_id = fallback_route_payload.get("route_id")
+    if not isinstance(fallback_route_id, str) or len(fallback_route_id) < 8:
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid fallback_route_id")
+
+    fallback_mark_healthy = client.patch(
+        f"/v1/routing/endpoints/{fallback_route_id}",
+        json={"health_status": "healthy"},
+    )
+    if fallback_mark_healthy.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"fallback route health update status={fallback_mark_healthy.status_code}")
 
     binding_response = client.post(
         "/v1/transports/bindings",
@@ -1986,8 +2026,12 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     if not isinstance(resolution, dict):
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid routing resolution response shape")
     selected_route = resolution.get("selected_route")
-    if not isinstance(selected_route, dict) or selected_route.get("route_id") != route_id:
-        return ContractResult("enterprise_naming_routing_delivery", False, "routing resolve selected route mismatch")
+    if not isinstance(selected_route, dict) or selected_route.get("route_id") != fallback_route_id:
+        return ContractResult("enterprise_naming_routing_delivery", False, "routing resolve fallback route mismatch")
+    if resolution.get("fallback_applied") is not True:
+        return ContractResult("enterprise_naming_routing_delivery", False, "fallback_applied should be true for unhealthy primary route")
+    if resolution.get("fallback_from_route_id") != route_id:
+        return ContractResult("enterprise_naming_routing_delivery", False, "fallback_from_route_id mismatch")
     resolver_chain = resolution.get("resolver_chain")
     if resolver_chain != ["alias", "principal_id", "endpoint_route", "transport_dispatch"]:
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid resolver_chain")
@@ -2010,8 +2054,8 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     delivery_id = delivery.get("delivery_id")
     if not isinstance(delivery_id, str) or len(delivery_id) < 8:
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid delivery_id")
-    if delivery.get("route_id") != route_id:
-        return ContractResult("enterprise_naming_routing_delivery", False, "delivery route_id mismatch")
+    if delivery.get("route_id") != fallback_route_id:
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery route_id should use fallback")
 
     replay_response = client.post(f"/v1/deliveries/{delivery_id}/replay")
     if replay_response.status_code != 200:
@@ -2021,6 +2065,71 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid delivery replay response shape")
     if replay_delivery.get("replay_of_delivery_id") != delivery_id:
         return ContractResult("enterprise_naming_routing_delivery", False, "delivery replay linkage mismatch")
+
+    disable_fallback_route = client.patch(
+        f"/v1/routing/endpoints/{fallback_route_id}",
+        json={"status": "inactive"},
+    )
+    if disable_fallback_route.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"fallback route disable status={disable_fallback_route.status_code}")
+
+    pending_delivery_response = client.post(
+        "/v1/deliveries",
+        json={
+            "org_id": org_id,
+            "workspace_id": workspace_id,
+            "alias": "agent://conformance/router",
+            "payload": {"event": "conformance.delivery.pending"},
+            "idempotency_key": f"conformance-dlv-pending-{uuid4()}",
+        },
+    )
+    if pending_delivery_response.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"pending delivery submit status={pending_delivery_response.status_code}")
+    pending_delivery = pending_delivery_response.json().get("delivery")
+    if not isinstance(pending_delivery, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid pending delivery response shape")
+    pending_delivery_id = pending_delivery.get("delivery_id")
+    if not isinstance(pending_delivery_id, str) or len(pending_delivery_id) < 8:
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid pending delivery_id")
+    if pending_delivery.get("status") != "pending":
+        return ContractResult("enterprise_naming_routing_delivery", False, "expected pending delivery status when only unhealthy route remains")
+    if pending_delivery.get("route_id") != route_id:
+        return ContractResult("enterprise_naming_routing_delivery", False, "pending delivery should route through primary route")
+
+    operations_response = client.get(
+        "/v1/deliveries-operations",
+        params={"org_id": org_id, "workspace_id": workspace_id, "window_hours": 24},
+    )
+    if operations_response.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"delivery operations status={operations_response.status_code}")
+    operations_payload = operations_response.json().get("operations")
+    if not isinstance(operations_payload, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid delivery operations response shape")
+    status_counts = operations_payload.get("status_counts")
+    if not isinstance(status_counts, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations missing status_counts")
+    if int(status_counts.get("pending", 0)) < 1:
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations missing pending status count")
+
+    reconcile_response = client.post(
+        "/v1/deliveries/reconcile",
+        json={
+            "org_id": org_id,
+            "workspace_id": workspace_id,
+            "max_pending_age_seconds": 0,
+            "limit": 100,
+        },
+    )
+    if reconcile_response.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"delivery reconcile status={reconcile_response.status_code}")
+    reconcile_payload = reconcile_response.json().get("reconciliation")
+    if not isinstance(reconcile_payload, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid delivery reconcile response shape")
+    if int(reconcile_payload.get("reconciled_count") or 0) < 1:
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery reconcile did not reconcile pending deliveries")
+    reconciled_ids = reconcile_payload.get("reconciled_delivery_ids")
+    if not isinstance(reconciled_ids, list) or pending_delivery_id not in reconciled_ids:
+        return ContractResult("enterprise_naming_routing_delivery", False, "reconciled delivery id missing from reconcile response")
 
     return ContractResult("enterprise_naming_routing_delivery", True, "ok")
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1280,12 +1280,36 @@ def test_run_contract_suite_happy_path() -> None:
                 "cluster_id": body.get("cluster_id"),
                 "failover_policy": body.get("failover_policy", "none"),
                 "priority": body.get("priority", 100),
-                "health_status": "healthy",
+                "health_status": body.get("health_status", "unknown"),
                 "status": "active",
                 "metadata": body.get("metadata", {}),
                 "created_at": "2026-02-28T00:00:00Z",
                 "updated_at": "2026-02-28T00:00:00Z",
             }
+            endpoint_routes[route_id] = route_payload
+            return httpx.Response(200, json={"ok": True, "route": route_payload})
+        if request.url.path.startswith("/v1/routing/endpoints/") and request.method == "PATCH":
+            if not has_authorization(request):
+                return httpx.Response(401, json={"error": "unauthorized"})
+            route_id = request.url.path.split("/v1/routing/endpoints/")[1]
+            route_payload = endpoint_routes.get(route_id)
+            if route_payload is None:
+                return httpx.Response(404, json={"error": "route_not_found"})
+            body = json.loads(request.content.decode("utf-8"))
+            route_payload = dict(route_payload)
+            for field in (
+                "endpoint_url",
+                "auth_mode",
+                "region",
+                "cluster_id",
+                "failover_policy",
+                "priority",
+                "health_status",
+                "status",
+            ):
+                if field in body and body.get(field) is not None:
+                    route_payload[field] = body[field]
+            route_payload["updated_at"] = "2026-02-28T00:00:05Z"
             endpoint_routes[route_id] = route_payload
             return httpx.Response(200, json={"ok": True, "route": route_payload})
         if request.url.path == "/v1/transports/bindings" and request.method == "POST":
@@ -1341,6 +1365,28 @@ def test_run_contract_suite_happy_path() -> None:
             if not routes:
                 return httpx.Response(404, json={"error": "route_not_found"})
             routes.sort(key=lambda item: int(item.get("priority", 100)))
+            primary_route = routes[0]
+            selected_route = primary_route
+            fallback_applied = False
+            fallback_from_route_id = None
+            fallback_reason = None
+            primary_health = str(primary_route.get("health_status") or "unknown")
+            primary_policy = str(primary_route.get("failover_policy") or "none")
+            if primary_health not in {"healthy", "degraded"}:
+                if primary_policy in {"same_region", "cross_region"}:
+                    for candidate in routes[1:]:
+                        candidate_health = str(candidate.get("health_status") or "unknown")
+                        if candidate_health not in {"healthy", "degraded"}:
+                            continue
+                        if primary_policy == "same_region" and candidate.get("region") != primary_route.get("region"):
+                            continue
+                        selected_route = candidate
+                        fallback_applied = True
+                        fallback_from_route_id = primary_route.get("route_id")
+                        fallback_reason = "primary_route_not_healthy"
+                        break
+                if not fallback_applied:
+                    fallback_reason = "no_healthy_fallback_route"
             return httpx.Response(
                 200,
                 json={
@@ -1348,8 +1394,12 @@ def test_run_contract_suite_happy_path() -> None:
                     "resolution": {
                         "alias": next((item for item in aliases.values() if item.get("alias") == alias_value), None),
                         "principal": principal,
-                        "selected_route": routes[0],
+                        "primary_route": primary_route,
+                        "selected_route": selected_route,
                         "candidate_routes": routes,
+                        "fallback_applied": fallback_applied,
+                        "fallback_from_route_id": fallback_from_route_id,
+                        "fallback_reason": fallback_reason,
                         "resolver_chain": ["alias", "principal_id", "endpoint_route", "transport_dispatch"],
                     },
                 },
@@ -1382,7 +1432,23 @@ def test_run_contract_suite_happy_path() -> None:
             routes = [route for route in endpoint_routes.values() if route.get("principal_id") == principal["principal_id"]]
             if not routes:
                 return httpx.Response(404, json={"error": "route_not_found"})
-            selected_route = sorted(routes, key=lambda item: int(item.get("priority", 100)))[0]
+            active_routes = [route for route in routes if route.get("status") == "active"]
+            if not active_routes:
+                return httpx.Response(404, json={"error": "route_not_found"})
+            active_routes.sort(key=lambda item: int(item.get("priority", 100)))
+            primary_route = active_routes[0]
+            selected_route = primary_route
+            primary_health = str(primary_route.get("health_status") or "unknown")
+            primary_policy = str(primary_route.get("failover_policy") or "none")
+            if primary_health not in {"healthy", "degraded"} and primary_policy in {"same_region", "cross_region"}:
+                for candidate in active_routes[1:]:
+                    candidate_health = str(candidate.get("health_status") or "unknown")
+                    if candidate_health not in {"healthy", "degraded"}:
+                        continue
+                    if primary_policy == "same_region" and candidate.get("region") != primary_route.get("region"):
+                        continue
+                    selected_route = candidate
+                    break
             delivery_id = f"dlv_{uuid4().hex[:24]}"
             delivery_payload = {
                 "delivery_id": delivery_id,
@@ -1393,7 +1459,7 @@ def test_run_contract_suite_happy_path() -> None:
                 "alias": alias_value,
                 "transport_type": selected_route["transport_type"],
                 "route_id": selected_route["route_id"],
-                "status": "delivered",
+                "status": "pending" if str(selected_route.get("health_status") or "unknown") in {"degraded", "unhealthy"} else "delivered",
                 "correlation_id": body.get("correlation_id"),
                 "idempotency_key": idempotency_key,
                 "payload": body.get("payload", {}),
@@ -1403,6 +1469,120 @@ def test_run_contract_suite_happy_path() -> None:
             }
             deliveries[delivery_id] = delivery_payload
             return httpx.Response(200, json={"ok": True, "delivery": delivery_payload})
+        if request.url.path == "/v1/deliveries-operations" and request.method == "GET":
+            if not has_authorization(request):
+                return httpx.Response(401, json={"error": "unauthorized"})
+            org_id = request.url.params.get("org_id")
+            workspace_id = request.url.params.get("workspace_id")
+            window_hours = request.url.params.get("window_hours")
+            filtered = [
+                item
+                for item in deliveries.values()
+                if (org_id is None or item.get("org_id") == org_id)
+                and (workspace_id is None or item.get("workspace_id") == workspace_id)
+            ]
+            status_counts = {"submitted": 0, "delivered": 0, "failed": 0, "pending": 0, "dead_lettered": 0}
+            by_transport: dict[str, dict[str, object]] = {}
+            by_route: dict[str, dict[str, object]] = {}
+            replay_count = 0
+            for item in filtered:
+                status = str(item.get("status") or "submitted")
+                transport_type = str(item.get("transport_type") or "unknown")
+                route_id = str(item.get("route_id") or "unknown")
+                if status in status_counts:
+                    status_counts[status] = int(status_counts[status]) + 1
+                if item.get("replay_of_delivery_id") is not None:
+                    replay_count += 1
+                if transport_type not in by_transport:
+                    by_transport[transport_type] = {
+                        "transport_type": transport_type,
+                        "total": 0,
+                        "status_counts": {"submitted": 0, "delivered": 0, "failed": 0, "pending": 0, "dead_lettered": 0},
+                        "error_rate": 0.0,
+                    }
+                transport_bucket = by_transport[transport_type]
+                transport_bucket["total"] = int(transport_bucket["total"]) + 1
+                transport_bucket["status_counts"][status] = int(transport_bucket["status_counts"].get(status, 0)) + 1
+                if route_id not in by_route:
+                    by_route[route_id] = {
+                        "route_id": route_id,
+                        "total": 0,
+                        "status_counts": {"submitted": 0, "delivered": 0, "failed": 0, "pending": 0, "dead_lettered": 0},
+                    }
+                route_bucket = by_route[route_id]
+                route_bucket["total"] = int(route_bucket["total"]) + 1
+                route_bucket["status_counts"][status] = int(route_bucket["status_counts"].get(status, 0)) + 1
+            for bucket in by_transport.values():
+                total = int(bucket["total"])
+                errors = int(bucket["status_counts"]["failed"]) + int(bucket["status_counts"]["dead_lettered"])
+                bucket["error_rate"] = float(errors / total) if total > 0 else 0.0
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "operations": {
+                        "org_id": org_id,
+                        "workspace_id": workspace_id,
+                        "window_hours": int(window_hours or 24),
+                        "window_start": "2026-02-27T00:00:00Z",
+                        "window_end": "2026-02-28T00:00:00Z",
+                        "total_deliveries": len(filtered),
+                        "replay_count": replay_count,
+                        "status_counts": status_counts,
+                        "by_transport": list(by_transport.values()),
+                        "by_route": list(by_route.values()),
+                    },
+                },
+            )
+        if request.url.path == "/v1/deliveries/reconcile" and request.method == "POST":
+            if not has_authorization(request):
+                return httpx.Response(401, json={"error": "unauthorized"})
+            body = json.loads(request.content.decode("utf-8"))
+            org_id = body.get("org_id")
+            workspace_id = body.get("workspace_id")
+            reconciled_ids: list[str] = []
+            by_transport: dict[str, int] = {}
+            by_route: dict[str, int] = {}
+            for delivery_id, item in list(deliveries.items()):
+                if item.get("status") != "pending":
+                    continue
+                if org_id is not None and item.get("org_id") != org_id:
+                    continue
+                if workspace_id is not None and item.get("workspace_id") != workspace_id:
+                    continue
+                next_item = dict(item)
+                next_item["status"] = "dead_lettered"
+                next_item["error_detail"] = "reconciled pending delivery after timeout"
+                next_item["updated_at"] = "2026-02-28T00:00:10Z"
+                deliveries[delivery_id] = next_item
+                reconciled_ids.append(delivery_id)
+                transport_type = str(next_item.get("transport_type") or "unknown")
+                route_id = str(next_item.get("route_id") or "unknown")
+                by_transport[transport_type] = int(by_transport.get(transport_type, 0)) + 1
+                by_route[route_id] = int(by_route.get(route_id, 0)) + 1
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "reconciliation": {
+                        "org_id": org_id,
+                        "workspace_id": workspace_id,
+                        "max_pending_age_seconds": int(body.get("max_pending_age_seconds", 300)),
+                        "limit": int(body.get("limit", 500)),
+                        "reconciled_count": len(reconciled_ids),
+                        "reconciled_delivery_ids": reconciled_ids,
+                        "by_transport": [
+                            {"transport_type": key, "count": by_transport[key]}
+                            for key in sorted(by_transport.keys())
+                        ],
+                        "by_route": [
+                            {"route_id": key, "count": by_route[key]}
+                            for key in sorted(by_route.keys())
+                        ],
+                        "reconciled_at": "2026-02-28T00:00:10Z",
+                    },
+                },
+            )
         if request.url.path.startswith("/v1/deliveries/") and request.url.path.endswith("/replay") and request.method == "POST":
             if not has_authorization(request):
                 return httpx.Response(401, json={"error": "unauthorized"})


### PR DESCRIPTION
## Summary
- extend enterprise routing/delivery conformance contract with failover fallback assertions
- validate delivery operations counters and pending->dead_lettered reconciliation path
- update conformance mock transport handler to support new routing and delivery ops semantics

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q tests/test_suite.py -k "run_contract_suite_happy_path or run_contract_suite_reports_failures"`

Made with [Cursor](https://cursor.com)