### PR TITLE
test: harden delivery conformance for parity and recovery counters

### DIFF
--- a/conformance/suite.py
+++ b/conformance/suite.py
@@ -1936,9 +1936,9 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
         "/v1/routing/endpoints",
         json={
             "principal_id": principal_id,
-            "transport_type": "http",
-            "endpoint_url": "https://conformance-router-primary.example/intents",
-            "auth_mode": "jwt",
+            "transport_type": "matrix",
+            "endpoint_url": "matrix://conformance-router-primary",
+            "auth_mode": "signed_key",
             "region": "us-central1",
             "failover_policy": "same_region",
             "priority": 5,
@@ -1995,6 +1995,54 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     if fallback_mark_healthy.status_code != 200:
         return ContractResult("enterprise_naming_routing_delivery", False, f"fallback route health update status={fallback_mark_healthy.status_code}")
 
+    queue_route_response = client.post(
+        "/v1/routing/endpoints",
+        json={
+            "principal_id": principal_id,
+            "transport_type": "queue",
+            "endpoint_url": "queue://conformance-router",
+            "auth_mode": "none",
+            "region": "us-central1",
+            "priority": 15,
+        },
+    )
+    if queue_route_response.status_code != 200:
+        return ContractResult(
+            "enterprise_naming_routing_delivery",
+            False,
+            f"routing queue endpoint register status={queue_route_response.status_code}",
+        )
+    queue_route_payload = queue_route_response.json().get("route")
+    if not isinstance(queue_route_payload, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid queue route response shape")
+    queue_route_id = queue_route_payload.get("route_id")
+    if not isinstance(queue_route_id, str) or len(queue_route_id) < 8:
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid queue_route_id")
+
+    queue_mark_healthy = client.patch(
+        f"/v1/routing/endpoints/{queue_route_id}",
+        json={"health_status": "healthy"},
+    )
+    if queue_mark_healthy.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"queue route health update status={queue_mark_healthy.status_code}")
+
+    matrix_binding_response = client.post(
+        "/v1/transports/bindings",
+        json={
+            "principal_id": principal_id,
+            "transport_type": "matrix",
+            "transport_handle": "@conformance-router:matrix.ax",
+            "priority": 5,
+            "status": "active",
+        },
+    )
+    if matrix_binding_response.status_code != 200:
+        return ContractResult(
+            "enterprise_naming_routing_delivery",
+            False,
+            f"matrix transport binding upsert status={matrix_binding_response.status_code}",
+        )
+
     binding_response = client.post(
         "/v1/transports/bindings",
         json={
@@ -2010,6 +2058,23 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
             "enterprise_naming_routing_delivery",
             False,
             f"transport binding upsert status={binding_response.status_code}",
+        )
+
+    queue_binding_response = client.post(
+        "/v1/transports/bindings",
+        json={
+            "principal_id": principal_id,
+            "transport_type": "queue",
+            "transport_handle": "queue://conformance-router",
+            "priority": 20,
+            "status": "active",
+        },
+    )
+    if queue_binding_response.status_code != 200:
+        return ContractResult(
+            "enterprise_naming_routing_delivery",
+            False,
+            f"queue transport binding upsert status={queue_binding_response.status_code}",
         )
 
     resolve_response = client.post(
@@ -2028,6 +2093,8 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     selected_route = resolution.get("selected_route")
     if not isinstance(selected_route, dict) or selected_route.get("route_id") != fallback_route_id:
         return ContractResult("enterprise_naming_routing_delivery", False, "routing resolve fallback route mismatch")
+    if selected_route.get("transport_type") != "http":
+        return ContractResult("enterprise_naming_routing_delivery", False, "routing resolve fallback transport should be http")
     if resolution.get("fallback_applied") is not True:
         return ContractResult("enterprise_naming_routing_delivery", False, "fallback_applied should be true for unhealthy primary route")
     if resolution.get("fallback_from_route_id") != route_id:
@@ -2056,6 +2123,9 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid delivery_id")
     if delivery.get("route_id") != fallback_route_id:
         return ContractResult("enterprise_naming_routing_delivery", False, "delivery route_id should use fallback")
+    if delivery.get("transport_type") != "http":
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery transport should be http on fallback")
+    expected_delivery_keys = set(delivery.keys())
 
     replay_response = client.post(f"/v1/deliveries/{delivery_id}/replay")
     if replay_response.status_code != 200:
@@ -2065,6 +2135,8 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
         return ContractResult("enterprise_naming_routing_delivery", False, "invalid delivery replay response shape")
     if replay_delivery.get("replay_of_delivery_id") != delivery_id:
         return ContractResult("enterprise_naming_routing_delivery", False, "delivery replay linkage mismatch")
+    if set(replay_delivery.keys()) != expected_delivery_keys:
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery replay response key shape mismatch")
 
     disable_fallback_route = client.patch(
         f"/v1/routing/endpoints/{fallback_route_id}",
@@ -2072,6 +2144,52 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     )
     if disable_fallback_route.status_code != 200:
         return ContractResult("enterprise_naming_routing_delivery", False, f"fallback route disable status={disable_fallback_route.status_code}")
+
+    queue_resolve_response = client.post(
+        "/v1/routing/resolve",
+        json={
+            "org_id": org_id,
+            "workspace_id": workspace_id,
+            "alias": "agent://conformance/router",
+        },
+    )
+    if queue_resolve_response.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"queue fallback resolve status={queue_resolve_response.status_code}")
+    queue_resolution = queue_resolve_response.json().get("resolution")
+    if not isinstance(queue_resolution, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid queue resolution response shape")
+    queue_selected = queue_resolution.get("selected_route")
+    if not isinstance(queue_selected, dict) or queue_selected.get("route_id") != queue_route_id:
+        return ContractResult("enterprise_naming_routing_delivery", False, "queue fallback route selection mismatch")
+    if queue_selected.get("transport_type") != "queue":
+        return ContractResult("enterprise_naming_routing_delivery", False, "queue fallback transport should be queue")
+
+    queue_delivery_response = client.post(
+        "/v1/deliveries",
+        json={
+            "org_id": org_id,
+            "workspace_id": workspace_id,
+            "alias": "agent://conformance/router",
+            "payload": {"event": "conformance.delivery.queue"},
+            "idempotency_key": f"conformance-dlv-queue-{uuid4()}",
+        },
+    )
+    if queue_delivery_response.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"queue delivery submit status={queue_delivery_response.status_code}")
+    queue_delivery = queue_delivery_response.json().get("delivery")
+    if not isinstance(queue_delivery, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid queue delivery response shape")
+    if queue_delivery.get("transport_type") != "queue":
+        return ContractResult("enterprise_naming_routing_delivery", False, "queue delivery transport mismatch")
+    if set(queue_delivery.keys()) != expected_delivery_keys:
+        return ContractResult("enterprise_naming_routing_delivery", False, "queue delivery response key shape mismatch")
+
+    disable_queue_route = client.patch(
+        f"/v1/routing/endpoints/{queue_route_id}",
+        json={"status": "inactive"},
+    )
+    if disable_queue_route.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"queue route disable status={disable_queue_route.status_code}")
 
     pending_delivery_response = client.post(
         "/v1/deliveries",
@@ -2110,6 +2228,16 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
         return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations missing status_counts")
     if int(status_counts.get("pending", 0)) < 1:
         return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations missing pending status count")
+    latency_payload = operations_payload.get("latency")
+    if not isinstance(latency_payload, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations missing latency rollup")
+    if "sample_count" not in latency_payload or "slo_attainment_rate" not in latency_payload:
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations latency rollup shape mismatch")
+    recovery_counters = operations_payload.get("recovery_counters")
+    if not isinstance(recovery_counters, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "delivery operations missing recovery counters")
+    if int(recovery_counters.get("pending_to_dead_lettered_count", 0)) != 0:
+        return ContractResult("enterprise_naming_routing_delivery", False, "recovery counters should be zero before reconcile")
 
     reconcile_response = client.post(
         "/v1/deliveries/reconcile",
@@ -2130,6 +2258,70 @@ def _check_enterprise_naming_routing_delivery_contract(client: httpx.Client) -> 
     reconciled_ids = reconcile_payload.get("reconciled_delivery_ids")
     if not isinstance(reconciled_ids, list) or pending_delivery_id not in reconciled_ids:
         return ContractResult("enterprise_naming_routing_delivery", False, "reconciled delivery id missing from reconcile response")
+
+    pending_delivery_response_2 = client.post(
+        "/v1/deliveries",
+        json={
+            "org_id": org_id,
+            "workspace_id": workspace_id,
+            "alias": "agent://conformance/router",
+            "payload": {"event": "conformance.delivery.pending.recovered"},
+            "idempotency_key": f"conformance-dlv-pending-recovered-{uuid4()}",
+        },
+    )
+    if pending_delivery_response_2.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"second pending delivery submit status={pending_delivery_response_2.status_code}")
+    pending_delivery_2 = pending_delivery_response_2.json().get("delivery")
+    if not isinstance(pending_delivery_2, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid second pending delivery response shape")
+    pending_delivery_id_2 = pending_delivery_2.get("delivery_id")
+    if not isinstance(pending_delivery_id_2, str) or len(pending_delivery_id_2) < 8:
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid second pending delivery id")
+    if pending_delivery_2.get("status") != "pending":
+        return ContractResult("enterprise_naming_routing_delivery", False, "second pending delivery status should be pending")
+
+    reconcile_to_delivered_response = client.post(
+        "/v1/deliveries/reconcile",
+        json={
+            "org_id": org_id,
+            "workspace_id": workspace_id,
+            "max_pending_age_seconds": 0,
+            "limit": 100,
+            "target_status": "delivered",
+            "reason": "operator recovery",
+        },
+    )
+    if reconcile_to_delivered_response.status_code != 200:
+        return ContractResult(
+            "enterprise_naming_routing_delivery",
+            False,
+            f"delivery reconcile-to-delivered status={reconcile_to_delivered_response.status_code}",
+        )
+    reconcile_to_delivered = reconcile_to_delivered_response.json().get("reconciliation")
+    if not isinstance(reconcile_to_delivered, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid reconcile-to-delivered response shape")
+    if str(reconcile_to_delivered.get("target_status")) != "delivered":
+        return ContractResult("enterprise_naming_routing_delivery", False, "reconcile-to-delivered target_status mismatch")
+    reconciled_ids_2 = reconcile_to_delivered.get("reconciled_delivery_ids")
+    if not isinstance(reconciled_ids_2, list) or pending_delivery_id_2 not in reconciled_ids_2:
+        return ContractResult("enterprise_naming_routing_delivery", False, "reconcile-to-delivered id missing from response")
+
+    operations_after_response = client.get(
+        "/v1/deliveries-operations",
+        params={"org_id": org_id, "workspace_id": workspace_id, "window_hours": 24},
+    )
+    if operations_after_response.status_code != 200:
+        return ContractResult("enterprise_naming_routing_delivery", False, f"delivery operations-after status={operations_after_response.status_code}")
+    operations_after_payload = operations_after_response.json().get("operations")
+    if not isinstance(operations_after_payload, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "invalid operations-after response shape")
+    recovery_after = operations_after_payload.get("recovery_counters")
+    if not isinstance(recovery_after, dict):
+        return ContractResult("enterprise_naming_routing_delivery", False, "missing recovery counters after reconcile")
+    if int(recovery_after.get("pending_to_dead_lettered_count", 0)) < 1:
+        return ContractResult("enterprise_naming_routing_delivery", False, "recovery counter pending_to_dead_lettered_count should be >=1")
+    if int(recovery_after.get("pending_to_delivered_count", 0)) < 1:
+        return ContractResult("enterprise_naming_routing_delivery", False, "recovery counter pending_to_delivered_count should be >=1")
 
     return ContractResult("enterprise_naming_routing_delivery", True, "ok")
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -30,6 +30,7 @@ def test_run_contract_suite_happy_path() -> None:
     endpoint_routes: dict[str, dict[str, object]] = {}
     transport_bindings: dict[str, dict[str, object]] = {}
     deliveries: dict[str, dict[str, object]] = {}
+    reconcile_events: list[dict[str, object]] = []
     invite_counter = 0
     media_counter = 0
     thread_id = "11111111-1111-4111-8111-111111111111"
@@ -1364,7 +1365,24 @@ def test_run_contract_suite_happy_path() -> None:
             ]
             if not routes:
                 return httpx.Response(404, json={"error": "route_not_found"})
-            routes.sort(key=lambda item: int(item.get("priority", 100)))
+            binding_candidates = [
+                item
+                for item in transport_bindings.values()
+                if item.get("principal_id") == principal["principal_id"] and item.get("status") == "active"
+            ]
+            binding_candidates.sort(key=lambda item: int(item.get("priority", 100)))
+            transport_priority: dict[str, int] = {}
+            for binding in binding_candidates:
+                transport_type = str(binding.get("transport_type") or "")
+                if transport_type and transport_type not in transport_priority:
+                    transport_priority[transport_type] = int(binding.get("priority", 100))
+            routes.sort(
+                key=lambda item: (
+                    int(transport_priority.get(str(item.get("transport_type") or ""), 10000)),
+                    int(item.get("priority", 100)),
+                    str(item.get("route_id") or ""),
+                )
+            )
             primary_route = routes[0]
             selected_route = primary_route
             fallback_applied = False
@@ -1435,7 +1453,24 @@ def test_run_contract_suite_happy_path() -> None:
             active_routes = [route for route in routes if route.get("status") == "active"]
             if not active_routes:
                 return httpx.Response(404, json={"error": "route_not_found"})
-            active_routes.sort(key=lambda item: int(item.get("priority", 100)))
+            binding_candidates = [
+                item
+                for item in transport_bindings.values()
+                if item.get("principal_id") == principal["principal_id"] and item.get("status") == "active"
+            ]
+            binding_candidates.sort(key=lambda item: int(item.get("priority", 100)))
+            transport_priority: dict[str, int] = {}
+            for binding in binding_candidates:
+                transport_type = str(binding.get("transport_type") or "")
+                if transport_type and transport_type not in transport_priority:
+                    transport_priority[transport_type] = int(binding.get("priority", 100))
+            active_routes.sort(
+                key=lambda item: (
+                    int(transport_priority.get(str(item.get("transport_type") or ""), 10000)),
+                    int(item.get("priority", 100)),
+                    str(item.get("route_id") or ""),
+                )
+            )
             primary_route = active_routes[0]
             selected_route = primary_route
             primary_health = str(primary_route.get("health_status") or "unknown")
@@ -1485,6 +1520,8 @@ def test_run_contract_suite_happy_path() -> None:
             by_transport: dict[str, dict[str, object]] = {}
             by_route: dict[str, dict[str, object]] = {}
             replay_count = 0
+            latency_samples_ms: list[float] = []
+            by_transport_latency_samples_ms: dict[str, list[float]] = {}
             for item in filtered:
                 status = str(item.get("status") or "submitted")
                 transport_type = str(item.get("transport_type") or "unknown")
@@ -1503,6 +1540,14 @@ def test_run_contract_suite_happy_path() -> None:
                 transport_bucket = by_transport[transport_type]
                 transport_bucket["total"] = int(transport_bucket["total"]) + 1
                 transport_bucket["status_counts"][status] = int(transport_bucket["status_counts"].get(status, 0)) + 1
+                if status in {"delivered", "failed", "dead_lettered"}:
+                    created_at = str(item.get("created_at") or "")
+                    updated_at = str(item.get("updated_at") or "")
+                    latency_ms = 10000.0 if created_at != updated_at else 0.0
+                    latency_samples_ms.append(latency_ms)
+                    if transport_type not in by_transport_latency_samples_ms:
+                        by_transport_latency_samples_ms[transport_type] = []
+                    by_transport_latency_samples_ms[transport_type].append(latency_ms)
                 if route_id not in by_route:
                     by_route[route_id] = {
                         "route_id": route_id,
@@ -1516,6 +1561,47 @@ def test_run_contract_suite_happy_path() -> None:
                 total = int(bucket["total"])
                 errors = int(bucket["status_counts"]["failed"]) + int(bucket["status_counts"]["dead_lettered"])
                 bucket["error_rate"] = float(errors / total) if total > 0 else 0.0
+                transport_type = str(bucket["transport_type"])
+                transport_latencies = by_transport_latency_samples_ms.get(transport_type, [])
+                sample_count = len(transport_latencies)
+                avg_ms = float(sum(transport_latencies) / sample_count) if sample_count > 0 else 0.0
+                bucket["latency"] = {
+                    "sample_count": sample_count,
+                    "slo_target_ms": 1000.0,
+                    "avg_ms": avg_ms,
+                    "p95_ms": avg_ms if sample_count > 0 else 0.0,
+                    "max_ms": max(transport_latencies) if sample_count > 0 else 0.0,
+                    "slo_attainment_rate": (
+                        float(sum(1 for value in transport_latencies if value <= 1000.0)) / float(sample_count)
+                        if sample_count > 0
+                        else 0.0
+                    ),
+                }
+            latency_sample_count = len(latency_samples_ms)
+            latency_avg_ms = (
+                float(sum(latency_samples_ms) / float(latency_sample_count))
+                if latency_sample_count > 0
+                else 0.0
+            )
+            pending_to_delivered_count = 0
+            pending_to_dead_lettered_count = 0
+            for event in reconcile_events:
+                if org_id is not None and event.get("org_id") != org_id:
+                    continue
+                if workspace_id is not None and event.get("workspace_id") != workspace_id:
+                    continue
+                count_value = int(event.get("reconciled_count") or 0)
+                if str(event.get("target_status") or "dead_lettered") == "delivered":
+                    pending_to_delivered_count += count_value
+                else:
+                    pending_to_dead_lettered_count += count_value
+            total_recovered = pending_to_delivered_count + pending_to_dead_lettered_count
+            recovery_denominator = total_recovered + int(status_counts["pending"])
+            pending_recovery_rate = (
+                float(total_recovered) / float(recovery_denominator)
+                if recovery_denominator > 0
+                else 0.0
+            )
             return httpx.Response(
                 200,
                 json={
@@ -1529,6 +1615,34 @@ def test_run_contract_suite_happy_path() -> None:
                         "total_deliveries": len(filtered),
                         "replay_count": replay_count,
                         "status_counts": status_counts,
+                        "latency": {
+                            "sample_count": latency_sample_count,
+                            "slo_target_ms": 1000.0,
+                            "avg_ms": latency_avg_ms,
+                            "p95_ms": latency_avg_ms if latency_sample_count > 0 else 0.0,
+                            "max_ms": max(latency_samples_ms) if latency_sample_count > 0 else 0.0,
+                            "slo_attainment_rate": (
+                                float(sum(1 for value in latency_samples_ms if value <= 1000.0)) / float(latency_sample_count)
+                                if latency_sample_count > 0
+                                else 0.0
+                            ),
+                        },
+                        "recovery_counters": {
+                            "pending_to_delivered_count": pending_to_delivered_count,
+                            "pending_to_dead_lettered_count": pending_to_dead_lettered_count,
+                            "total_recovered": total_recovered,
+                            "pending_recovery_rate": pending_recovery_rate,
+                            "delivered_recovery_share": (
+                                float(pending_to_delivered_count) / float(total_recovered)
+                                if total_recovered > 0
+                                else 0.0
+                            ),
+                            "dead_lettered_recovery_share": (
+                                float(pending_to_dead_lettered_count) / float(total_recovered)
+                                if total_recovered > 0
+                                else 0.0
+                            ),
+                        },
                         "by_transport": list(by_transport.values()),
                         "by_route": list(by_route.values()),
                     },
@@ -1540,7 +1654,12 @@ def test_run_contract_suite_happy_path() -> None:
             body = json.loads(request.content.decode("utf-8"))
             org_id = body.get("org_id")
             workspace_id = body.get("workspace_id")
+            target_status = str(body.get("target_status") or "dead_lettered")
+            reason = body.get("reason")
+            if target_status not in {"delivered", "dead_lettered"}:
+                return httpx.Response(422, json={"error": "invalid_target_status"})
             reconciled_ids: list[str] = []
+            by_target_status = {"delivered": 0, "dead_lettered": 0}
             by_transport: dict[str, int] = {}
             by_route: dict[str, int] = {}
             for delivery_id, item in list(deliveries.items()):
@@ -1551,15 +1670,27 @@ def test_run_contract_suite_happy_path() -> None:
                 if workspace_id is not None and item.get("workspace_id") != workspace_id:
                     continue
                 next_item = dict(item)
-                next_item["status"] = "dead_lettered"
-                next_item["error_detail"] = "reconciled pending delivery after timeout"
+                next_item["status"] = target_status
+                if target_status == "dead_lettered":
+                    next_item["error_detail"] = str(reason or "reconciled pending delivery after timeout")
+                else:
+                    next_item["error_detail"] = str(reason) if isinstance(reason, str) else None
                 next_item["updated_at"] = "2026-02-28T00:00:10Z"
                 deliveries[delivery_id] = next_item
                 reconciled_ids.append(delivery_id)
+                by_target_status[target_status] = int(by_target_status[target_status]) + 1
                 transport_type = str(next_item.get("transport_type") or "unknown")
                 route_id = str(next_item.get("route_id") or "unknown")
                 by_transport[transport_type] = int(by_transport.get(transport_type, 0)) + 1
                 by_route[route_id] = int(by_route.get(route_id, 0)) + 1
+            reconcile_events.append(
+                {
+                    "org_id": org_id,
+                    "workspace_id": workspace_id,
+                    "target_status": target_status,
+                    "reconciled_count": len(reconciled_ids),
+                }
+            )
             return httpx.Response(
                 200,
                 json={
@@ -1569,8 +1700,10 @@ def test_run_contract_suite_happy_path() -> None:
                         "workspace_id": workspace_id,
                         "max_pending_age_seconds": int(body.get("max_pending_age_seconds", 300)),
                         "limit": int(body.get("limit", 500)),
+                        "target_status": target_status,
                         "reconciled_count": len(reconciled_ids),
                         "reconciled_delivery_ids": reconciled_ids,
+                        "by_target_status": by_target_status,
                         "by_transport": [
                             {"transport_type": key, "count": by_transport[key]}
                             for key in sorted(by_transport.keys())


### PR DESCRIPTION
## Summary
- extend enterprise routing/delivery contract checks for matrix/http/queue parity
- validate latency and recovery counters exposed by delivery operations endpoint
- validate reconcile target status support for dead-letter and delivered recovery transitions
- update conformance mock handler to mirror transport priority and recovery semantics

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q tests/test_suite.py -k "run_contract_suite_happy_path or run_contract_suite_reports_failures"`

Made with [Cursor](https://cursor.com)