### PR TITLE
docs: align alpha access URL and contact wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,6 @@ A conformance check is considered passing only when it succeeds against:
 ## Contributing & Contact
 
 - New conformance check proposals: open an issue with label `conformance-proposal`
-- Alpha program and access: [hello@axme.ai](mailto:hello@axme.ai)
+- Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
 - Security disclosures: see [SECURITY.md](SECURITY.md)
 - Contribution guidelines: [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- Update README alpha-access wording to use https://cloud.axme.ai/alpha.
- Keep hello@axme.ai as the contact channel for suggestions and communication.

## Test plan
- [x] Verify README alpha-access lines point to https://cloud.axme.ai/alpha.
- [x] Verify hello@axme.ai remains for contact/suggestions.
